### PR TITLE
build.sh: added missing ref to Generated.Custom.cs, format commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,29 @@ if [ -z "$2" ]; then
   exit 1
 fi
 
-mcs /out:ClangSharpPInvokeGenerator.exe ClangSharpPInvokeGenerator/ClangSharp.Extensions.cs ClangSharpPInvokeGenerator/EnumVisitor.cs ClangSharpPInvokeGenerator/Extensions.cs ClangSharpPInvokeGenerator/ForwardDeclarationVisitor.cs ClangSharpPInvokeGenerator/FunctionVisitor.cs ClangSharpPInvokeGenerator/Generated.cs ClangSharpPInvokeGenerator/ICXCursorVisitor.cs ClangSharpPInvokeGenerator/Program.cs ClangSharpPInvokeGenerator/StructVisitor.cs ClangSharpPInvokeGenerator/TypeDefVisitor.cs
-mono ClangSharpPInvokeGenerator.exe --m clang --p clang_ --namespace ClangSharp --output Generated.cs --libraryPath $1 --include $2 --file $2/clang-c/Index.h --file $2/clang-c/CXString.h --file $2/clang-c/Documentation.h --file $2/clang-c/CXErrorCode.h
+mcs /out:ClangSharpPInvokeGenerator.exe \
+	ClangSharpPInvokeGenerator/ClangSharp.Extensions.cs \
+	ClangSharpPInvokeGenerator/EnumVisitor.cs \
+	ClangSharpPInvokeGenerator/Extensions.cs \
+	ClangSharpPInvokeGenerator/ForwardDeclarationVisitor.cs \
+	ClangSharpPInvokeGenerator/FunctionVisitor.cs \
+	ClangSharpPInvokeGenerator/Generated.cs \
+	ClangSharpPInvokeGenerator/Generated.Custom.cs \
+	ClangSharpPInvokeGenerator/ICXCursorVisitor.cs \
+	ClangSharpPInvokeGenerator/Program.cs \
+	ClangSharpPInvokeGenerator/StructVisitor.cs \
+	ClangSharpPInvokeGenerator/TypeDefVisitor.cs
+
+mono ClangSharpPInvokeGenerator.exe \
+	--m clang \
+	--p clang_ \
+	--namespace ClangSharp \
+	--output Generated.cs \
+	--libraryPath $1 \
+	--include $2 \
+	--file $2/clang-c/Index.h \
+	--file $2/clang-c/CXString.h \
+	--file $2/clang-c/Documentation.h \
+	--file $2/clang-c/CXErrorCode.h
+
 mcs /target:library /out:ClangSharp.dll Generated.cs Extensions.cs


### PR DESCRIPTION
Reference to `Generated.Custom.cs` is missed, leads to build error:
```
ClangSharpPInvokeGenerator/Program.cs(106,50): error CS0117: `ClangSharp.clang' does not contain a definition for `parseTranslationUnit2'
```

Formatted the commands into multiple lines for readability.

Permission of build.sh is changed from 644 → 755.